### PR TITLE
fix: add .gitattributes to render .luau files as Lua

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.luau linguist-language=Lua


### PR DESCRIPTION
This improves syntax highlighting for better readability.
